### PR TITLE
Expect DER signature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,6 @@ let package = Package(
     ],
     dependencies: [ ],
     targets: [
-        // .binaryTarget(name: "RustFramework", url: "https://github.com/spruceid/wallet-sdk-rs/releases/download/0.0.24/RustFramework.xcframework.zip", checksum: "f8ca19a431e05bfc4275e47b0074895dc85ac7228e54c7fce8679e037e63be31"),
         .binaryTarget(name: "RustFramework", url: "https://github.com/spruceid/wallet-sdk-rs/releases/download/0.0.24/RustFramework.xcframework.zip", checksum: "f8ca19a431e05bfc4275e47b0074895dc85ac7228e54c7fce8679e037e63be31"),
         .target(
             name: "SpruceIDWalletSdkRs",


### PR DESCRIPTION
Because both iOS and Android generate DER by default and Android doesn't have an easy way of doing the translation.